### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/brehldev/opensearch-filter-proxy/security/code-scanning/3](https://github.com/brehldev/opensearch-filter-proxy/security/code-scanning/3)

To fix the problem, add a top-level `permissions` block to the workflow YAML file, directly below the `name:` or `on:` section (before `env:` or `jobs:`), specifying the minimal required permissions for all jobs. For typical CI jobs that only need to read code and upload artifacts, `contents: read` is usually sufficient. This ensures that the automatically provided GITHUB_TOKEN is limited to read access, adhering to the least privilege principle. No existing functionality will be affected, as these jobs do not push commits, modify issues, or interact with PRs. The best edit is to insert:

```yaml
permissions:
  contents: read
```

as a new block just after the workflow `on:` events.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
